### PR TITLE
Update path for ORM page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
       - Maps: go-instructions/collections/maps.md
       - Slices: go-instructions/collections/slices.md
   - ORM: 
-    - ORM: orm.md
+    - ORM: orm/orm.md
     - gorm: orm/gorm.md
   - Logging:
     - Logging: logging/logging.md


### PR DESCRIPTION
The menu is point to a wrong place for the ORM/ORM link.
It's referring `https://mehdihadeli.github.io/awesome-go-education/orm.md` which file does not exist and breaks the rendering of the rest of the template because of that.
The correct path should be https://mehdihadeli.github.io/awesome-go-education/orm/orm