### PR TITLE
Fix links to ORM and gorm

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,8 +103,8 @@ nav:
       - Maps: go-instructions/collections/maps.md
       - Slices: go-instructions/collections/slices.md
   - ORM:
-    - ORM: orm/orm.md
-    - gorm: orm/gorm.md
+    - ORM: database/orm/orm.md
+    - gorm: database/orm/gorm.md
   - Logging: logging.md
   - DDD: ddd.md
   - Clean Architecture: clean-architecture.md


### PR DESCRIPTION
The main page currently links from the ORM > ORM menu item to https://mehdihadeli.github.io/awesome-go-education/orm/orm.md which is 404.

The correct link can be found under Go Instructions > Database > ORM > ORM to https://mehdihadeli.github.io/awesome-go-education/database/orm/orm/

The same error is present for gorm. This patch fixes the path to both pages.